### PR TITLE
Update pip requirements with direct links to the missing packages

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -349,9 +349,9 @@ dependencies:
     - dill==0.3.3
     - django==3.0.8
     - editdistance==0.5.3
-    - en-core-web-sm==2.2.5
+    - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#en_core_web_sm
     - en-core-web-sm-mirror==2.2.5
-    - en-ner-jnlpba-md==0.2.4
+    - https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.2.4/en_ner_jnlpba_md-0.2.4.tar.gz
     - flaky==3.6.1
     - flask-cors==3.0.8
     - frozendict==1.2
@@ -373,7 +373,7 @@ dependencies:
     - oauthlib==3.1.0
     - overrides==3.0.0
     - parsimonious==0.8.1
-    - predpatt==1.0
+    - https://github.com/hltcoe/PredPatt/tarball/master#egg=predpatt
     - preshed==3.0.2
     - protobuf==3.12.2
     - pyarrow==2.0.0


### PR DESCRIPTION
This should fix the missing packages issue when running `conda env create -f env.yml`